### PR TITLE
fixes for newer allensdk

### DIFF
--- a/mcmodels/core/voxel_model_api.py
+++ b/mcmodels/core/voxel_model_api.py
@@ -4,7 +4,7 @@ Module containing VoxelModelApi.
 # Authors: Joseph Knox <josephk@alleninstitute.org>
 # License: Allen Institute Software License
 
-from allensdk.api.cache import cacheable, Cache
+from allensdk.api.warehouse_cache.cache import cacheable, Cache
 from allensdk.api.queries.mouse_connectivity_api import MouseConnectivityApi
 
 


### PR DESCRIPTION
"cache" was renamed "warehouse_cache"